### PR TITLE
Use 127.0.0.1 instead of localhost to workaround broken Windows 11

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -60,7 +60,7 @@ async function getClientsNow(verbosity: Verbosity = 0): Promise<ClientStatus[]> 
     let statuses: ClientStatus[] = []
     for (const port of CLIENT_PORTS) {
         /** Defined in bkclientjsStatusHandler in https://github.com/BlenderKit/BlenderKit/blob/main/client/main.go. */
-        const url: string = `http://localhost:${port}/bkclientjs/status`;
+        const url: string = `http://127.0.0.1:${port}/bkclientjs/status`;
         let clientStatus = await _tryClientStatus(url, verbosity)
         if (clientStatus === null) {
             continue
@@ -109,7 +109,7 @@ async function _tryClientStatus(url: string, verbosity: Verbosity = 0): Promise<
  */
 async function downloadAssetToSoftware (clientPort: string, appID: number, assetID: string, assetBaseID: string, resolution: string, apiKey: string): Promise<boolean> {
     /** Defined in bkclientjsGetAssetHandler in https://github.com/BlenderKit/BlenderKit/blob/main/client/main.go. */
-    const url = `http://localhost:${clientPort}/bkclientjs/get_asset`;
+    const url = `http://127.0.0.1:${clientPort}/bkclientjs/get_asset`;
     const data = JSON.stringify({
         "api_key": apiKey,
         "asset_id": assetID,


### PR DESCRIPTION
Windows 11 is getting broken more and more with every update, and Oct 2025 update broke localhost and currently on Windows 11 machines, queries to various ports where no client is running (which are nearly instant on linux) take a second on Windows 11, probably due to HTTP 2 bug (it looks like timeout as opposed to connection refused) but honestly I'm not paid by Micro$oft to debug their slop.

It takes 13 s or more to finish searching clients and softwares which used to be almost instant as it still is on linux.

So, before wasting more time with hacking around M$ incompetence yet again with forced timeouts, here is an attempt to workaround which helped for Godot plugin.

Same queries against 127.0.0.1 seem to be instant, possibly because Windows downgrades to HTTP/1.1 which isn't bugged or because the buggy code is bypassed for another reason.

This also could (or not) help with CORS denials, only one way to find out.