### PR TITLE
Parallelize client discovery with per-request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # bkclientjs
+
 JavaScript library for communication between Server and locally running BlenderKit-Client.
 Library allows to order in browser the asset downloads to the softwares connected to BlenderKit-Client.
 
@@ -8,25 +9,28 @@ Library allows to order in browser the asset downloads to the softwares connecte
 
 For usage on devel and production server, the library build is released into `dev` and `prod` branches.
 `dev` branch is build every time there is a push to `main` branch, the `prod` branch build needs to be triggered manually.
-Files are located in `dist` folder. 
+Files are located in `dist` folder.
 (For archival reasons, or when exact version control is needed, the library is also released via GitHub Releases with semantic versioning.)
 
 Production files:
+
 - https://raw.githubusercontent.com/BlenderKit/bkclientjs/refs/heads/prod/dist/main.js
 - https://raw.githubusercontent.com/BlenderKit/bkclientjs/refs/heads/prod/dist/main.d.ts
 
 Development files:
+
 - https://raw.githubusercontent.com/BlenderKit/bkclientjs/refs/heads/dev/dist/main.js
 - https://raw.githubusercontent.com/BlenderKit/bkclientjs/refs/heads/dev/dist/main.d.ts
 
 You can also access the files via jsDelivr CDN:
+
 - https://cdn.jsdelivr.net/gh/BlenderKit/bkclientjs@prod/dist/main.js
 - https://cdn.jsdelivr.net/gh/BlenderKit/bkclientjs@prod/dist/main.d.ts
 - https://cdn.jsdelivr.net/gh/BlenderKit/bkclientjs@dev/dist/main.js
 - https://cdn.jsdelivr.net/gh/BlenderKit/bkclientjs@dev/dist/main.d.ts
 
-
 ### Get running Clients
+
 With the library you can easily scan localhost for all currently running BlenderKit-Clients.
 Library returns found Clients as array of ClientStatus - array is empty if no Client responded.
 Normally there should be 1 Client, but can be more in rare cases.
@@ -38,6 +42,7 @@ Client is uniquely identified by its Port.
 Software is uniquely identified by its PID (Process ID).
 
 ### Schedule download
+
 User is presented with download options on the asset they are previewing in the browser asset gallery.
 E.g.: they see they have 2 Blenders and 1 Godot connected. They choose download to Godot.
 You can ask for the download with this library specifying the AssetID, software PID, apiToken and clientPort.
@@ -49,26 +54,42 @@ For Godot and other softwares we might just download the asset into specified di
 ### Example:
 
 If you want to get the Clients on demand right now:
+
 ```javascript
-let client = await bkclientjs.getClientsNow()
+let client = await bkclientjs.getClientsNow();
 if (client.length === 0) {
-    return
+  return;
 }
-const ok = bkclientjs.downloadAssetToSoftware(client.port, client.software[0].appID, assetID, assetBaseID, resolution, apiKey)
+const ok = bkclientjs.downloadAssetToSoftware(
+  client.port,
+  client.software[0].appID,
+  assetID,
+  assetBaseID,
+  resolution,
+  apiKey,
+);
 ```
 
 Or you can start a polling and then get the Clients from variable filled by the polling:
+
 ```javascript
 bkclientjs.startClientPolling(1000); // library will check for the Clients every 1000ms,
 
 // later - ideally in your own Timeout update function
 // results are available without need for await via:
-let clients = bkclientjs.getClients()
+let clients = bkclientjs.getClients();
 
 // or you can get the list of all software - this is what cares of:
-let softwares = bkclientjs.getSoftwares()
+let softwares = bkclientjs.getSoftwares();
 
-const ok = bkclientjs.downloadAssetToSoftware(softwares[0].clientPort, softwares[0].appID, assetID, assetBaseID, resolution, apiKey)
+const ok = bkclientjs.downloadAssetToSoftware(
+  softwares[0].clientPort,
+  softwares[0].appID,
+  assetID,
+  assetBaseID,
+  resolution,
+  apiKey,
+);
 ```
 
 ### Verbosity
@@ -76,6 +97,7 @@ const ok = bkclientjs.downloadAssetToSoftware(softwares[0].clientPort, softwares
 You can make the library more verbose by calling the with verbosity 1 (INFO) or 2 (DEBUG): `bkclientjs.startClientPolling(1000, 2);`.
 
 ## Developing
+
 1. `npm install`
 2. `npm run build` - compile TS to JS in ./dist
 3. `npx http-server` - serve the example index.html file

--- a/README.md
+++ b/README.md
@@ -77,9 +77,12 @@ You can make the library more verbose by calling the with verbosity 1 (INFO) or 
 
 ## Developing
 1. `npm install`
-1. `npm run build` - compile TS to JS in ./dist
-2. `http-server` - serve the example index.html file
-3. navigate to localhost:8080, on refresh browser tries to fetch data from locally running BlenderKit-client, prints to console
+2. `npm run build` - compile TS to JS in ./dist
+3. `npx http-server` - serve the example index.html file
+4. navigate to http://localhost:8080 - browser tries to fetch data from locally
+   running BlenderKit-client.
+
+**NOTE**: `127.0.0.1` gets treated differently than `localhost` in CORS - `localhost` might work where `127.0.0.1` doesn't.
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If you want to get the Clients on demand right now:
 
 ```javascript
 let client = await bkclientjs.getClientsNow();
+// custom discovery timeout of 333 ms:
+// let client = await bkclientjs.getClientsNow(0, 333);
 if (client.length === 0) {
   return;
 }
@@ -90,6 +92,15 @@ const ok = bkclientjs.downloadAssetToSoftware(
   resolution,
   apiKey,
 );
+```
+
+You can also pass an options object as the third argument to configure the callback and/or discovery timeout:
+
+```javascript
+bkclientjs.startClientPolling(1000, 0, {
+  onUpdate: (clients) => { /* called after each poll */ },
+  timeoutMs: 333, // per-request discovery timeout in ms
+});
 ```
 
 ### Verbosity

--- a/index.html
+++ b/index.html
@@ -3,188 +3,273 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Web -> Client -> Godot</title>
+    <title>bkclientjs dev</title>
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
-    <h1>Download from browser to Godot PoC</h1>    
-    <div>
-      Softwares
-      <select id="software">
-        <option value="" disabled selected>Select Software</option>
-      </select>
-      (dynamically detected, make sure at least 1 client is running)
-    </div>
-    
-    <div>
-      Project Name = <span id="project-name"></span>
-    </div>
-    <div>
-      Software AppID = <span id="app-id"></span>
-    </div>
-    <div>
-      Client Port = <span id="port"></span>
+
+    <div class="top-bar">
+      <h1>bkclientjs dev</h1>
+      <div class="badge" id="poll-badge">
+        <span class="dot" id="poll-dot"></span>
+        <span id="poll-label">stopped</span>
+      </div>
+      <button id="btn-scan">Scan Now</button>
     </div>
 
-    </br>
+    <div class="polling-info">
+      <span>Scan: <strong id="info-scan-time">-</strong></span>
+      <span>Clients: <strong id="info-client-count">0</strong></span>
+      <span>Softwares: <strong id="info-sw-count">0</strong></span>
+    </div>
 
-    <div>
-      APIKey
-      <input type="text" id="api-key" placeholder="API Key" value="">
-      (this will fill in the webpage, because user is logged-in)
-    </div>
-        
-    <div>
-      AssetID
-      <input type="text" id="asset-id" placeholder="Asset ID" value="0992088b-fb84-4c69-bb6e-426272970c8b">
-      (this will fill the webpage, we know on which asset user clicks the download)
-    </div>
-    
-    <div>
-      Asset Base ID
-      <input type="text" id="asset-base-id" placeholder="Asset Base ID" value="67f55944-a088-48de-8a60-6132547cbf75">
-      (this will fill the webpage, we know on which asset user clicks the download)
-    </div>
-    
-    <div>
-      Resolution
-      <input type="text" id="resolution" placeholder="Resolution" value="resolution_4K">
-      (user will choose)
-    </div>
-    
-    <button id="download">Download</button>
+    <!-- Ports -->
+    <section>
+      <div class="section-header">
+        <h2>Ports</h2>
+      </div>
+      <div class="ports-grid" id="ports-grid"></div>
+    </section>
 
-    <div>
-      <h2>Clients</h2>
-      <ul id="client-list">
-        <!-- List of connected clients will be populated here -->
-      </ul>
-    </div>
+    <!-- Clients -->
+    <section>
+      <div class="section-header">
+        <h2>Clients</h2>
+        <span class="count" id="clients-count"></span>
+        <button class="json-toggle" id="btn-clients-json">raw json</button>
+      </div>
+      <div class="card-grid" id="clients-grid"></div>
+      <div class="json-block" id="clients-json"></div>
+    </section>
+
+    <!-- Softwares -->
+    <section>
+      <div class="section-header">
+        <h2>Softwares</h2>
+        <span class="count" id="sw-count"></span>
+        <button class="json-toggle" id="btn-sw-json">raw json</button>
+      </div>
+      <div class="card-grid" id="sw-grid"></div>
+      <div class="json-block" id="sw-json"></div>
+    </section>
+
+    <!-- Download -->
+    <section>
+      <h2>Download Asset</h2>
+      <br>
+      <div class="form-grid">
+        <label for="f-software">Software</label>
+        <select id="f-software">
+          <option value="" disabled selected>Select software</option>
+        </select>
+
+        <label for="f-api-key">API Key</label>
+        <input type="text" id="f-api-key" placeholder="api key">
+
+        <label for="f-asset-id">Asset ID</label>
+        <input type="text" id="f-asset-id" placeholder="asset id" value="0992088b-fb84-4c69-bb6e-426272970c8b">
+
+        <label for="f-asset-base-id">Asset Base ID</label>
+        <input type="text" id="f-asset-base-id" placeholder="asset base id" value="67f55944-a088-48de-8a60-6132547cbf75">
+
+        <label for="f-resolution">Resolution</label>
+        <input type="text" id="f-resolution" placeholder="resolution" value="resolution_4K">
+      </div>
+
+      <div class="download-bar">
+        <button class="primary" id="btn-download">Download</button>
+        <span id="download-status"></span>
+      </div>
+    </section>
 
     <script type="module">
-      import bkclientjs from './dist/main.js'; // import as ESNext module
-      let clients = [];
-      const pollingInterval = 500;
-    
-      // Function to populate the client list with available clients
-      async function populateClientList() {
-        clients = await bkclientjs.getClients();
-        const clientList = document.getElementById("client-list");
-    
-        // Clear the existing client list
-        clientList.innerHTML = '';
-    
-        if (!clients || clients.length === 0) {
-          console.log("No Clients running.");
-          return;
-        }
-    
-        // Populate the list with connected clients
-        clients.forEach(client => {
-          const listItem = document.createElement("li");
-          listItem.textContent = `Client on port ${client.port} (version: ${client.clientVersion})`;
-          clientList.appendChild(listItem);
-        });
-    
-        // Update the software dropdown with the latest software
-        populateSoftwareDropdown();
-      }
-    
-      let isDropdownFocused = false; // Flag to track if the dropdown is focused
-    
-      // Function to populate the software dropdown with available software
-      async function populateSoftwareDropdown() {
-        if (isDropdownFocused) {
-          // Don't update the dropdown if the user is interacting with it
-          return;
-        }
-    
-        const softwareSelect = document.getElementById("software");
-    
-        // Save the currently selected value
-        const selectedValue = softwareSelect.value;
-    
-        // Clear existing options (keep the placeholder)
-        softwareSelect.innerHTML = '<option value="" disabled selected>Select Software</option>';
-    
-        const softwares = await bkclientjs.getSoftwares();
-    
-        if (!softwares || softwares.length === 0) {
-          console.log("No Software running.");
-          return;
-        }
-    
-        softwares.forEach(software => {
-          const option = document.createElement("option");
-          option.value = software.appID; // Use the appID as the value
-          option.textContent = `${software.name} (v${software.version})`;
-          softwareSelect.appendChild(option);
-        });
-    
-        // Restore the previously selected value if it exists
-        if (selectedValue) {
-          softwareSelect.value = selectedValue;
-        }
+      import bkclientjs from './dist/main.js';
+
+      // --- State ---
+      const POLL_INTERVAL = 5000;
+      const POLL_VERBOSITY = 1;
+      const CLIENT_PORTS = ["62485","65425","55428","49452","35452","25152","5152","1234"];
+      let latestClients = [];
+      let firstFetchDone = false;
+
+      // --- DOM refs ---
+      const $pollDot      = document.getElementById('poll-dot');
+      const $pollLabel     = document.getElementById('poll-label');
+      const $infoScanTime  = document.getElementById('info-scan-time');
+      const $infoClients   = document.getElementById('info-client-count');
+      const $infoSw        = document.getElementById('info-sw-count');
+      const $portsGrid     = document.getElementById('ports-grid');
+      const $clientsGrid   = document.getElementById('clients-grid');
+      const $clientsCount  = document.getElementById('clients-count');
+      const $clientsJson   = document.getElementById('clients-json');
+      const $swGrid        = document.getElementById('sw-grid');
+      const $swCount       = document.getElementById('sw-count');
+      const $swJson        = document.getElementById('sw-json');
+      const $software      = document.getElementById('f-software');
+      const $dlStatus      = document.getElementById('download-status');
+
+      function escapeHtml(s) {
+        return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
       }
 
-      // Event listener for when a software is selected
-      document.getElementById("software").addEventListener("change", function() {
-        const selectedAppID = this.value; // Get the selected appID
-        // Find the client and port associated with the selected software
-        let selectedProjectName = "";
-        let selectedPort = "";
-        for (let client of clients) {
-          for (let software of client.softwares) {
-            if (software.appID == selectedAppID) {
-              selectedProjectName = software.projectName;
-              selectedPort = client.port;
-              break;
-            }
+      // --- Ports display ---
+      function renderPorts(activePorts) {
+        $portsGrid.innerHTML = CLIENT_PORTS.map(p => {
+          let cls = 'port-row';
+          if (!firstFetchDone) cls += ' port-unknown';
+          else if (activePorts.has(p)) cls += ' port-active';
+          else cls += ' port-inactive';
+          return `<div class="${cls}"><span class="port-dot"></span><span class="port-number">${p}</span></div>`;
+        }).join('');
+      }
+      renderPorts(new Set()); // initial render - all black
+
+      // --- Timed scan wrapper ---
+      async function timedScan(verbosity) {
+        const t0 = performance.now();
+        const clients = await bkclientjs.getClientsNow(verbosity);
+        const ms = Math.round(performance.now() - t0);
+        $infoScanTime.textContent = `${ms} ms`;
+        firstFetchDone = true;
+        return clients;
+      }
+
+      // --- Render ---
+      function renderClients(clients) {
+        latestClients = clients || [];
+        const count = latestClients.length;
+        $infoClients.textContent = count;
+        $clientsCount.textContent = `(${count})`;
+
+        // Polling badge
+        $pollDot.className = 'dot ' + (count > 0 ? 'green' : 'yellow');
+        $pollLabel.textContent = count > 0 ? `${count} client${count > 1 ? 's' : ''}` : 'polling...';
+
+        // Ports
+        const activePorts = new Set(latestClients.map(c => c.port));
+        renderPorts(activePorts);
+
+        // Client cards
+        if (count === 0) {
+          $clientsGrid.innerHTML = '<div class="empty-msg">No clients detected. Make sure at least one client is running.</div>';
+        } else {
+          $clientsGrid.innerHTML = latestClients.map((c, i) => `
+            <div class="card">
+              <dl>
+                <dt>Port</dt><dd>${c.port}</dd>
+                <dt>Client Version</dt><dd>${c.clientVersion}</dd>
+                <dt>Softwares</dt><dd>${c.softwares.length}</dd>
+              </dl>
+              <button class="json-toggle" onclick="this.nextElementSibling.classList.toggle('open')">raw json</button>
+              <div class="json-block">${escapeHtml(JSON.stringify(c, null, 2))}</div>
+            </div>
+          `).join('');
+        }
+
+        // Raw JSON for all clients
+        $clientsJson.textContent = JSON.stringify(latestClients, null, 2);
+
+        // Softwares
+        renderSoftwares();
+        renderSoftwareDropdown();
+      }
+
+      function renderSoftwares() {
+        const softwares = [];
+        for (const c of latestClients) {
+          for (const sw of c.softwares) {
+            softwares.push({ ...sw, _clientPort: c.port });
           }
-          if (selectedPort) break;
         }
-        // Update the AppID and Port spans
-        document.getElementById("project-name").textContent = selectedProjectName; // Update the Project name
-        document.getElementById("app-id").textContent = selectedAppID; // Update the AppID span
-        document.getElementById("port").textContent = selectedPort; // Update the Port span
-      });
-    
-      // Add event listeners to pause and resume dropdown updates
-      document.getElementById("software").addEventListener("focus", () => {
-        isDropdownFocused = true;
-      });
-    
-      document.getElementById("software").addEventListener("blur", () => {
-        isDropdownFocused = false;
-      });
-    
-      // Function to handle the download button click
-      async function DownloadButtonClicked() {
-        const apiKey = document.getElementById("api-key").value;
-        const appID = document.getElementById("app-id").textContent;
-        const port = document.getElementById("port").textContent;
-        const assetID = document.getElementById("asset-id").value;
-        const assetBaseID = document.getElementById("asset-base-id").value;
-        const resolution = document.getElementById("resolution").value;
-    
-        if (!apiKey || !appID || !assetID || !assetBaseID || !resolution || !port) {
-          alert("Please fill all required fields.");
-          return;
+        const count = softwares.length;
+        $infoSw.textContent = count;
+        $swCount.textContent = `(${count})`;
+
+        if (count === 0) {
+          $swGrid.innerHTML = '<div class="empty-msg">No softwares detected. Start a software with the add-on enabled.</div>';
+        } else {
+          $swGrid.innerHTML = softwares.map(sw => `
+            <div class="card">
+              <dl>
+                <dt>Name</dt><dd>${escapeHtml(sw.name)}</dd>
+                <dt>Version</dt><dd>${escapeHtml(sw.version)}</dd>
+                <dt>PID (appID)</dt><dd>${sw.appID}</dd>
+                <dt>Add-on Version</dt><dd>${escapeHtml(sw.addonVersion)}</dd>
+                <dt>Project</dt><dd>${escapeHtml(sw.projectName || '(none)')}</dd>
+                <dt>Client Port</dt><dd>${sw._clientPort}</dd>
+              </dl>
+              <button class="json-toggle" onclick="this.nextElementSibling.classList.toggle('open')">raw json</button>
+              <div class="json-block">${escapeHtml(JSON.stringify(sw, null, 2))}</div>
+            </div>
+          `).join('');
         }
-    
-        let ok = await bkclientjs.downloadAssetToSoftware(port, appID, assetID, assetBaseID, resolution, apiKey, );
-        console.log("Download ok:", ok)
+
+        $swJson.textContent = JSON.stringify(softwares, null, 2);
       }
 
-      document.getElementById("download").addEventListener("click", DownloadButtonClicked)
-    
-      // Start polling and updating the clients and software lists periodically
-      window.onload = function() {
-        bkclientjs.startClientPolling();
-        populateClientList(); // Initial population
-        setInterval(populateClientList, pollingInterval); // Periodic update of the clientList
-      };
+      // --- Software dropdown for download ---
+      let dropdownFocused = false;
+      $software.addEventListener('focus', () => { dropdownFocused = true; });
+      $software.addEventListener('blur',  () => { dropdownFocused = false; });
+
+      function renderSoftwareDropdown() {
+        if (dropdownFocused) return;
+        const prev = $software.value;
+        $software.innerHTML = '<option value="" disabled selected>Select software</option>';
+        for (const c of latestClients) {
+          for (const sw of c.softwares) {
+            const opt = document.createElement('option');
+            opt.value = JSON.stringify({ port: c.port, appID: sw.appID });
+            opt.textContent = `${sw.name} v${sw.version} - ${sw.projectName || 'no project'} (port ${c.port})`;
+            $software.appendChild(opt);
+          }
+        }
+        if (prev) $software.value = prev;
+      }
+
+      // --- JSON toggles for section-level ---
+      document.getElementById('btn-clients-json').addEventListener('click', () => {
+        $clientsJson.classList.toggle('open');
+      });
+      document.getElementById('btn-sw-json').addEventListener('click', () => {
+        $swJson.classList.toggle('open');
+      });
+
+      // --- Download ---
+      document.getElementById('btn-download').addEventListener('click', async () => {
+        const swVal = $software.value;
+        if (!swVal) { $dlStatus.textContent = 'Select a software first'; $dlStatus.className = 'fail'; return; }
+        const { port, appID } = JSON.parse(swVal);
+        const apiKey      = document.getElementById('f-api-key').value;
+        const assetID     = document.getElementById('f-asset-id').value;
+        const assetBaseID = document.getElementById('f-asset-base-id').value;
+        const resolution  = document.getElementById('f-resolution').value;
+
+        if (!apiKey || !assetID || !assetBaseID || !resolution) {
+          $dlStatus.textContent = 'Fill all fields'; $dlStatus.className = 'fail'; return;
+        }
+
+        $dlStatus.textContent = 'sending...'; $dlStatus.className = '';
+        const ok = await bkclientjs.downloadAssetToSoftware(port, appID, assetID, assetBaseID, resolution, apiKey);
+        $dlStatus.textContent = ok ? 'OK - download scheduled' : 'FAILED';
+        $dlStatus.className = ok ? 'ok' : 'fail';
+      });
+
+      // --- Scan Now ---
+      document.getElementById('btn-scan').addEventListener('click', async () => {
+        console.log('Manual scan triggered');
+        const clients = await timedScan(2);
+        renderClients(clients);
+      });
+
+      // --- Start polling manually so we can measure scan time ---
+      renderClients([]); // initial empty render
+      async function poll() {
+        const clients = await timedScan(POLL_VERBOSITY);
+        renderClients(clients);
+      }
+      poll(); // immediate first scan
+      setInterval(poll, POLL_INTERVAL);
     </script>
 
   </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ export default bkclientjs;
 
 /** As defined in CLIENT_PORTS in https://github.com/BlenderKit/BlenderKit/blob/main/global_vars.py */
 let CLIENT_PORTS = ["62485", "65425", "55428", "49452", "35452", "25152", "5152", "1234"];
-let pollingInterval: ReturnType<typeof setInterval> | undefined; 
+let pollingInterval: ReturnType<typeof setInterval> | undefined;
 let connectedClients: ClientStatus[];
 /** Lock to prevent overlapping polling cycles. */
 let _pollingBusy = false;
@@ -104,7 +104,7 @@ async function _tryClientStatus(url: string, verbosity: Verbosity = 0): Promise<
  * @param assetBaseID - which asset to download TODO: remove this or assetBaseID and require just one
  * @param resolution - resolution of the asset - user should probably select this in the gallery
  * @param apiKey - apiKey of the logged user on the webpage - no need to sync the keys between several softwares
- * @param appID - Process ID of the running software to which we will download - list of all softwares is part of the 
+ * @param appID - Process ID of the running software to which we will download - list of all softwares is part of the
  * @returns true if download was successfully scheduled, otherwise false.
  */
 async function downloadAssetToSoftware (clientPort: string, appID: number, assetID: string, assetBaseID: string, resolution: string, apiKey: string): Promise<boolean> {
@@ -165,10 +165,10 @@ function getSoftwares(): Software[] {
 
 
 /** Start periodic polling/search on localhost for available Clients (and Softwares connected to them).
- * 
+ *
  * @param {number} [interval=5000] how often the bkclientjs should check for the running Clients and Softwares
  * @param {boolean} [verbosity=0] true it will print debug info about the request to Client
- * @returns 
+ * @returns
  */
 async function startClientPolling(
     interval: number = 5000,
@@ -226,5 +226,5 @@ function stopClientPolling() {
     }
     clearInterval(pollingInterval);
     pollingInterval = undefined;
-    console.log("Polling stopped.");    
+    console.log("Polling stopped.");
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,9 +9,10 @@ const bkclientjs = {
 export default bkclientjs;
 
 /** As defined in CLIENT_PORTS in https://github.com/BlenderKit/BlenderKit/blob/main/global_vars.py */
-let CLIENT_PORTS = ["62485", "65425", "55428", "49452", "35452", "25152", "5152", "1234"];
+const CLIENT_PORTS = ["62485", "65425", "55428", "49452", "35452", "25152", "5152", "1234"];
+const DISCOVERY_TIMEOUT_MS = 250;
 let pollingInterval: ReturnType<typeof setInterval> | undefined;
-let connectedClients: ClientStatus[];
+let connectedClients: ClientStatus[] = [];
 /** Lock to prevent overlapping polling cycles. */
 let _pollingBusy = false;
 type UpdateCallback = (clients: ClientStatus[]) => void | Promise<void>;
@@ -51,44 +52,76 @@ interface Software {
  */
 type Verbosity = 0 | 1 | 2;
 
+function normalizeDiscoveryTimeoutMs(timeoutMs: number): number {
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+        return DISCOVERY_TIMEOUT_MS;
+    }
+    return timeoutMs;
+}
+
 /** Scan for the Clients right now. Make requests iterating over all possible ports Client can have on the localhost
  * and get their ClientStatuses if possible. Use the statuses to update UI and inform user where they can download the asset from browser gallery.
  * @param verbosity
- * @returns first successful response from local Client or null if something went wrong.
+ * @param timeoutMs timeout for each discovery request in milliseconds
+ * @returns discovered local Clients or empty array if none responded.
  */
-async function getClientsNow(verbosity: Verbosity = 0): Promise<ClientStatus[]> {
-    let statuses: ClientStatus[] = []
-    for (const port of CLIENT_PORTS) {
+async function getClientsNow(
+    verbosity: Verbosity = 0,
+    timeoutMs: number = DISCOVERY_TIMEOUT_MS
+): Promise<ClientStatus[]> {
+    const effectiveTimeoutMs = normalizeDiscoveryTimeoutMs(timeoutMs);
+    const statuses = await Promise.all(CLIENT_PORTS.map(async (port) => {
         /** Defined in bkclientjsStatusHandler in https://github.com/BlenderKit/BlenderKit/blob/main/client/main.go. */
         const url: string = `http://localhost:${port}/bkclientjs/status`;
-        let clientStatus = await _tryClientStatus(url, verbosity)
+        let clientStatus = await _tryClientStatus(url, verbosity, effectiveTimeoutMs)
         if (clientStatus === null) {
-            continue
+            return null;
         }
         clientStatus.port = port;
-        statuses.push(clientStatus);
-    }
-    return statuses;
+        return clientStatus;
+    }));
+    return statuses.filter((status): status is ClientStatus => status !== null);
 }
 
 /** Try to get the ClientStatus on selected address. This can fail as we are not sure if Client is available there.
  * Returns the status if Client runs on the URL, or null if the request has failed or response is not OK (could be another software running there).
  * @param url Address where to check if Client replies
+ * @param timeoutMs Timeout for a single discovery request in milliseconds
  * @returns response of the Client or null if something went wrong
  */
-async function _tryClientStatus(url: string, verbosity: Verbosity = 0): Promise<ClientStatus|null> {
+async function _tryClientStatus(
+    url: string,
+    verbosity: Verbosity = 0,
+    timeoutMs: number = DISCOVERY_TIMEOUT_MS
+): Promise<ClientStatus|null> {
     let clientStatus: ClientStatus
+    let controller: AbortController | undefined;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    if (typeof AbortController === "function") {
+        controller = new AbortController();
+        timeoutHandle = setTimeout(() => controller?.abort(), timeoutMs);
+    } else if (verbosity > 1) {
+        console.debug("AbortController not available, discovery timeout disabled for:", url);
+    }
     try {
-        const resp = await fetch(url);
+        const resp = await fetch(url, controller ? { signal: controller.signal } : undefined);
         if (resp.status !== 200) {
             if (verbosity > 0) console.log(`Wrong status code: ${resp.status}`);
             return null;
         }
-        console.log("Client response:", resp)
+        if (verbosity > 1) console.log("Client response:", resp);
         clientStatus = await resp.json() as ClientStatus;
     } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+            if (verbosity > 1) console.debug(`Discovery timeout (${timeoutMs}ms): ${url}`);
+            return null;
+        }
         if (verbosity > 1) console.error("Error getting response:", err);
         return null;
+    } finally {
+        if (timeoutHandle !== undefined) {
+            clearTimeout(timeoutHandle);
+        }
     }
 
     if (clientStatus.softwares === null) {
@@ -164,17 +197,29 @@ function getSoftwares(): Software[] {
 // MARK: POLLING
 
 
+interface PollingOptions {
+    onUpdate?: UpdateCallback;
+    timeoutMs?: number;
+}
+
 /** Start periodic polling/search on localhost for available Clients (and Softwares connected to them).
  *
  * @param {number} [interval=5000] how often the bkclientjs should check for the running Clients and Softwares
- * @param {boolean} [verbosity=0] true it will print debug info about the request to Client
- * @returns
+ * @param {number} [verbosity=0] how verbose the logging should be (0=fatal, 1=info, 2=debug)
+ * @param {UpdateCallback | PollingOptions} [onUpdateOrOptions] options object, or a bare UpdateCallback for backward compat
  */
 async function startClientPolling(
     interval: number = 5000,
     verbosity: Verbosity = 0,
-    onUpdate?: UpdateCallback
+    onUpdateOrOptions?: UpdateCallback | PollingOptions,
 ): Promise<void> {
+    const onUpdate = typeof onUpdateOrOptions === 'function'
+        ? onUpdateOrOptions
+        : onUpdateOrOptions?.onUpdate;
+    const timeoutMs = typeof onUpdateOrOptions === 'object'
+        ? (onUpdateOrOptions?.timeoutMs ?? DISCOVERY_TIMEOUT_MS)
+        : DISCOVERY_TIMEOUT_MS;
+
     if (pollingInterval) {
         console.log("Polling is already running");
         return;
@@ -182,8 +227,8 @@ async function startClientPolling(
 
     try { // Start polling right away
         _pollingBusy = true;
-        connectedClients = await getClientsNow(verbosity);
-        console.log("Updated clients:", connectedClients);
+        connectedClients = await getClientsNow(verbosity, timeoutMs);
+        if (verbosity > 0) console.log("Updated clients:", connectedClients);
     } catch (error) {
         if (verbosity > 0) console.error("Error while fetching clients (immediate):", error);
     } finally {
@@ -206,7 +251,7 @@ async function startClientPolling(
 
         _pollingBusy = true;
         try {
-            connectedClients = await getClientsNow(verbosity);
+            connectedClients = await getClientsNow(verbosity, timeoutMs);
             if (verbosity > 0) console.log("Updated clients:", connectedClients);
             if (onUpdate) await onUpdate(connectedClients); // <- runs AFTER cycle finishes
         } catch (error) {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,252 @@
+:root {
+  --bg: #1a1a2e;
+  --surface: #16213e;
+  --surface2: #0f3460;
+  --accent: #e94560;
+  --accent-dim: #a33245;
+  --text: #eee;
+  --text-dim: #94a3b8;
+  --green: #22c55e;
+  --yellow: #eab308;
+  --red: #ef4444;
+  --mono: "SF Mono", "Cascadia Code", "Fira Code", Consolas, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --radius: 6px;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+  padding: 1rem 1.5rem;
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+h1 { font-size: 1.25rem; font-weight: 600; }
+h2 { font-size: 1rem; font-weight: 600; margin-bottom: 0.5rem; }
+
+/* Top bar */
+.top-bar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--surface2);
+}
+.top-bar h1 { flex: 1; }
+
+/* Status badge */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-family: var(--mono);
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--surface2);
+}
+.badge .dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--text-dim);
+}
+.badge .dot.green { background: var(--green); }
+.badge .dot.yellow { background: var(--yellow); animation: pulse 1.5s infinite; }
+.badge .dot.red { background: var(--red); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+/* Buttons */
+button, .btn {
+  font-family: var(--sans);
+  font-size: 0.8rem;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid var(--surface2);
+  border-radius: var(--radius);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+button:hover { background: var(--surface2); }
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+button.primary:hover { background: var(--accent-dim); }
+
+/* Sections */
+section {
+  margin-bottom: 1.25rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+.section-header h2 { margin-bottom: 0; }
+
+/* Cards */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--surface2);
+  border-radius: var(--radius);
+  padding: 0.75rem;
+}
+.card dt {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.card dd {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  margin-bottom: 0.4rem;
+}
+
+.empty-msg {
+  color: var(--text-dim);
+  font-size: 0.85rem;
+  font-style: italic;
+  padding: 0.5rem 0;
+}
+
+/* JSON toggle */
+.json-toggle {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  margin-top: 0.25rem;
+}
+.json-toggle:hover { color: var(--text); }
+.json-block {
+  display: none;
+  margin-top: 0.4rem;
+  background: var(--bg);
+  border-radius: var(--radius);
+  padding: 0.5rem;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 200px;
+  overflow-y: auto;
+  color: var(--text-dim);
+}
+.json-block.open { display: block; }
+
+/* Polling info bar */
+.polling-info {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  font-family: var(--mono);
+  color: var(--text-dim);
+  background: var(--surface);
+  border: 1px solid var(--surface2);
+  border-radius: var(--radius);
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1.25rem;
+}
+.polling-info span strong {
+  color: var(--text);
+}
+
+/* Download form */
+.form-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.4rem 0.75rem;
+  align-items: center;
+  font-size: 0.85rem;
+}
+.form-grid label {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  text-align: right;
+}
+.form-grid input, .form-grid select {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  padding: 0.3rem 0.5rem;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--surface2);
+  border-radius: var(--radius);
+  outline: none;
+}
+.form-grid input:focus, .form-grid select:focus {
+  border-color: var(--accent);
+}
+
+.download-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+#download-status {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+}
+#download-status.ok { color: var(--green); }
+#download-status.fail { color: var(--red); }
+
+/* Ports grid */
+.ports-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 0.4rem;
+}
+.port-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--radius);
+  background: var(--surface);
+  border: 1px solid var(--surface2);
+}
+.port-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.port-unknown .port-dot { background: var(--text-dim); }
+.port-active .port-dot { background: var(--green); }
+.port-inactive .port-dot { background: var(--red); }
+.port-active { border-color: var(--green); }
+.port-inactive { opacity: 0.5; }
+
+.section-header .count {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}


### PR DESCRIPTION
This counters strange and unwelcome behavior of Windows 11 where fetches
were taking 1-6 seconds before returning CORS error leading to
unacceptable client discovery time of 15 - 30.

For comparison, the entire operation took about 20 ms on linux as the
requests end instantly with CONNECTION REFUSED (as expected).

This might be some security shenanigens, but I suspect incompetence as
Microsoft is doing insane vibe-coding on Windows breaking everything
including localhost...

This new parallel approach with per-request timeouts (500 ms) has an
added benefit of not emmiting fetch errors into console on discovery as
they get aborted before failing.

Aside from not spamming the console with 8 red errors per second, this
might also prevent unwanted Sentry calls on failed fetch requests.